### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/src/backend/api_server.py
+++ b/src/backend/api_server.py
@@ -425,7 +425,8 @@ def askgilfi_query():
         })
     
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.exception("Error in /api/askgilfi/query")
+        return jsonify({'error': 'Internal server error'}), 500
 
 
 @app.route('/api/modules', methods=['GET'])


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-Robotiko/Gilfi/security/code-scanning/8](https://github.com/Mr-Robotiko/Gilfi/security/code-scanning/8)

To fix this, do not return raw exception details to the client. Instead:
1. Log the exception on the server side for debugging/operations.
2. Return a generic error message to the client.

Best minimal fix in `src/backend/api_server.py`:
- In `askgilfi_query()` at the `except Exception as e:` block (lines 427–428 in the snippet), replace `jsonify({'error': str(e)})` with a generic message like `jsonify({'error': 'Internal server error'})`.
- Add server-side logging using Flask’s app logger with stack trace context: `app.logger.exception("Error in /api/askgilfi/query")`.
- Keep status code 500 unchanged to preserve API behavior.

No functional change to successful responses; only sensitive error disclosure is removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
